### PR TITLE
Website updates config section

### DIFF
--- a/docs/wegue-configuration.md
+++ b/docs/wegue-configuration.md
@@ -17,16 +17,15 @@ This describes the Wegue application configuration, which is modelled as JSON do
 | showCopyrightYear |  | Boolean value, whether the copyright year should be shown on the right side of the toolbar | `"showCopyrightYear": true` or `"showCopyrightYear": false` | 
 | mapZoom           | x | Initial zoom level of the map | `"mapZoom": 2` |
 | mapCenter         | x | Initial center of the map in map projection | `"mapCenter": [0, 0]` |
-| mapProjection     |   | Configuration object for CRS / projection used for the map | see [mapProjection](wegue-configuration?id=wegue-configuration) |
+| mapProjection     |   | Configuration object for CRS / projection used for the map | see [mapProjection](wegue-configuration?id=mapprojection) |
 | modules           | x | Array of module configuration objects | See [modules](module-configuration) |
 | mapLayers         | x | Array of map layer configuration objects | See [mapLayers](map-layer-configuration) |
 | projectionDefs    |   | Array of CRS / projection definition objects compatible to proj4js | See [projectionDefs](wegue-configuration?id=projectiondefs) |
-| tileGridDefs      |   | Array of tile grid definition objects | |
+| tileGridDefs      |   | Array of tile grid definition objects | See [tileGridDefs](wegue-configuration?id=tilegriddefs) |
 
 ### projectionDefs
 
-The property `projectionDefs` is an array holding several proj4j compatible projection definitions in the form
-of a nested array, where the first item is the projection code and the second item is the proj4js definition string. For example:
+The property `projectionDefs` is a nested array holding several [proj4js](https://proj4js.org) compatible projection definitions. For each array element the first item is the projection code and the second item is the [proj4](https://proj4.org) definition string. For example:
 
 ```json
 [
@@ -34,7 +33,7 @@ of a nested array, where the first item is the projection code and the second it
     "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.999908 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812 +no_defs"
 ]
 ```
-The projection definition can be found at [epsg.io](http://epsg.io). The definition in the example above would therefore be available at http://epsg.io/28992.
+Projection definitions can be found at [epsg.io](http://epsg.io). The definition in the example above would therefore be available at http://epsg.io/28992.
 
 ### mapProjection
 
@@ -44,11 +43,48 @@ The property `mapProjection` defines the CRS, which is used by the map in your W
 |-------------------|-----------|---------|---------|
 | code              | x | The code of the SRS to be used for the map. In case it is not `EPSG:4326` or `EPSG:3857` it has to be defined in the [projectionDefs](wegue-configuration?id=projectiondefs) | `"code": "EPSG:28992"` |
 | units             | x | The unit of the SRS | `"units": "m"` |
-| extent             | x | The validity extent for the SRS | `"extent": [-285401.920, 22598.080, 595401.920, 903401.920]` |
+| extent            | x | The validity extent for the SRS | `"extent": [-285401.920, 22598.080, 595401.920, 903401.920]` |
+
+### tileGridDefs
+
+By default Wegue (OpenLayers) assumes the "OSM/Google" Web Mercator tilegrid. Different tilegrids can be defined once and then referenced in Layer configurations.
+Below is an example for the Dutch Standard Tilegrid:
+
+```json
+"tileGridDefs": {
+    "dutch_rd": {
+      "extent": [-285401.920, 22598.080, 595401.920, 903401.920],
+      "resolutions": [3440.640, 1720.320, 860.160, 430.080, 215.040, 107.520, 53.760, 26.880, 13.440, 6.720, 3.360, 1.680, 0.840, 0.420, 0.210],
+      "tileSize": [256, 256]
+    }
+  }
+ ```
+ One or more tilegrids can be defined. The tilegrid's name is arbitrary, above `dutch_rd`, and can be used as a key when refered in in a Layer configuration.
+ Each tilegrid definition has the following properties:
+ 
+| Property          | Mandatory | Meaning | Example |
+|-------------------|-----------|---------|---------|
+| extent            | x | The extent of the tilegrid as a bounding box using the SRS of the Map| `"extent": [-285401.920, 22598.080, 595401.920, 903401.920]` |
+| resolutions       | x | The resolutions for the tilegrid (related to zoomlevels) as an array | `"resolutions": [3440.640, 1720.320, 860.160, 430.080, 215.040, 107.520]` |
+| tileSize          | x | The tilesize in width/height pixels | `"tileSize": [512, 512]` |
+
+In a Layer configuration a specific tilegrid can be refered to as follows, using the `tileGridRef` property:
+
+```
+    {
+      "type": "XYZ",
+      "lid": "brtachtergrondkaart",
+      "name": "WMTS - Topo Basemap - PDOK",
+      "url": "https://geodata.nationaalgeoregister.nl/tiles/service/wmts/brtachtergrondkaart/EPSG:28992/{z}/{x}/{y}.png",
+      "projection": "EPSG:28992",
+      "tileGridRef": "dutch_rd",
+      "visible": true
+    }
+```
 
 ## Example configuration
 
-Several example configurations can be found here or take a look at the one below:
+Example configurations can be found in the `app-starter/static` directory. Below an example as used in the Demo:
 
 ```json
 {
@@ -66,21 +102,6 @@ Several example configurations can be found here or take a look at the one below
 
   "mapZoom": 2,
   "mapCenter": [0, 0],
-
-  "projectionDefs": [
-    [
-    "EPSG:28992",
-    "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.999908 +x_0=155000 +y_0=463000 +ellps=bessel +units=m +towgs84=565.2369,50.0087,465.658,-0.406857330322398,0.350732676542563,-1.8703473836068,4.0812 +no_defs"
-    ]
-  ],
-
-  "tileGridDefs": {
-    "dutch_rd": {
-      "extent": [-285401.920, 22598.080, 595401.920, 903401.920],
-      "resolutions": [3440.640, 1720.320, 860.160, 430.080, 215.040, 107.520, 53.760, 26.880, 13.440, 6.720, 3.360, 1.680, 0.840, 0.420, 0.210],
-      "tileSize": [256, 256]
-    }
-  },
 
   "mapLayers": [
 
@@ -225,3 +246,6 @@ Several example configurations can be found here or take a look at the one below
   }
 }
 ```
+
+A more elaborate example, named [app-conf-projected.json](https://github.com/meggsimum/wegue/blob/master/app-starter/static/app-conf-projected.json) with custom Projections and Tilegrids can be found in the app-starter directory.
+


### PR DESCRIPTION
* fix link to  `mapprojection` section
* various rephrasing
* added proj4-related links
* tilegrid config definition
* remove Projection and Tilegrid config from example config (they are not used in the config furhter)
* use 2 examples: the one from the demo and link to one with projections